### PR TITLE
Refactor: Update Categories and Tags Page Routes

### DIFF
--- a/pages/categories/index.vue
+++ b/pages/categories/index.vue
@@ -47,14 +47,9 @@ import type { Category } from '~/utils/types/category';
 
 const links = [
 	{
-		label: 'Products',
-		icon: ICONS.PRODUCT,
-		to: '/products',
-	},
-	{
 		label: 'All Categories',
 		icon: ICONS.LIST,
-		to: '/products/categories',
+		to: '/categories',
 	},
 ];
 

--- a/pages/tags/index.vue
+++ b/pages/tags/index.vue
@@ -46,14 +46,9 @@ import type { Tag } from '~/utils/types/tag';
 
 const links = [
 	{
-		label: 'Products',
-		icon: ICONS.PRODUCT,
-		to: '/products',
-	},
-	{
 		label: 'All Tags',
 		icon: ICONS.LIST,
-		to: '/products/tags',
+		to: '/tags',
 	},
 ];
 

--- a/stores/AppUi/AppUi.ts
+++ b/stores/AppUi/AppUi.ts
@@ -18,13 +18,13 @@ const merchantNavigation = [
 	{
 		title: 'Categories',
 		icon: ICONS.CATEGORY,
-		to: '/products/categories',
+		to: '/categories',
 		isCollapsed: true,
 	},
 	{
 		title: 'Tags',
 		icon: ICONS.TAG,
-		to: '/products/tags',
+		to: '/tags',
 		isCollapsed: true,
 	},
 	{


### PR DESCRIPTION
- Removed dedicated pages for categories and tags under /products
- Updated navigation links to point directly to /categories and /tags
- Simplified routing structure for categories and tags management