### PR TITLE
Refactor: Remove Unused Orders Component and Update Type Definitions

### DIFF
--- a/components/Dashboard/Chart/Orders.vue
+++ b/components/Dashboard/Chart/Orders.vue
@@ -1,0 +1,56 @@
+<template>
+	<UCard>
+		<template #header>
+			<div class="w-full">
+				<h1>Order Summary</h1>
+			</div>
+		</template>
+		<Bar id="my-chart-id" :options="chartOptions" :data="chartData" />
+		<template #footer>
+			<div class="w-full flex justify-end items-center text-secondary-400 gap-2">
+				<p class="text-sm text-end">Details</p>
+				<UIcon :name="ICONS.CHEVRON_RIGHT" class="w-6 h-6" />
+			</div>
+		</template>
+	</UCard>
+</template>
+
+<script lang="ts" setup>
+import { Bar } from 'vue-chartjs';
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js';
+
+ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
+
+const summOrderStore = useSummOrderStore();
+const { daily_summaries } = storeToRefs(summOrderStore);
+
+const chartData = {
+	labels: daily_summaries.value.map((summary) => summary.biz_date),
+	datasets: [
+		{
+			barThickness: 12,
+			maxBarThickness: 14,
+			minBarLength: 2,
+			label: 'Total Orders',
+			data: daily_summaries.value.map((summary) => summary.summ_order.total_orders),
+			backgroundColor: '#F79D65',
+			borderColor: '#FCDCC8',
+			borderWidth: 1,
+			fill: false,
+		},
+	],
+};
+
+const chartOptions = {
+	responsive: true,
+	scales: {
+		y: {
+			beginAtZero: true,
+			suggestedMin: 1,
+			suggestedMax: 10,
+		},
+	},
+};
+</script>
+
+<style scoped lang="postcss"></style>

--- a/components/Dashboard/Orders.vue
+++ b/components/Dashboard/Orders.vue
@@ -1,7 +1,0 @@
-<template>
-	<div></div>
-</template>
-
-<script lang="ts" setup></script>
-
-<style scoped lang="postcss"></style>

--- a/components/Z/Input/Product/GeneralInfo.vue
+++ b/components/Z/Input/Product/GeneralInfo.vue
@@ -171,7 +171,7 @@ const long_desc = computed({
 // +1 because the type is 1-indexed
 const product_type = computed({
 	get() {
-		return props.type - 1;
+		return (props.type ?? 0) - 1;
 	},
 	set(value) {
 		emit('update:type', value + 1);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,9 +3,7 @@
 		<UBreadcrumb :links="links" />
 		<div class="container">
 			<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-6 md:grid-rows-2 gap-4">
-				<DashboardChartSales class="col-span-1 sm:col-span-2 sm:row-span-2 md:col-span-4" />
-				<DashboardChartProducts class="col-span-1 sm:col-span-2 md:col-span-2" />
-				<DashboardChartVisitors class="col-span-1 sm:col-span-2 md:col-span-2" />
+				<DashboardChartOrders class="col-span-1 sm:col-span-2 sm:row-span-2 md:col-span-4" />
 			</div>
 			<!-- <div class="grid grid-cols-3 mt-4 gap-4">
 				<DashboardChartSales class="col-span-1" />

--- a/repository/modules/summ-order/models/response/dashboard-summ.ts
+++ b/repository/modules/summ-order/models/response/dashboard-summ.ts
@@ -1,11 +1,11 @@
-type SummOrderTxnDaily = {
+type SummOrderTxnDaily_ = {
 	biz_date: Date;
 	total_orders: number;
 	total_qty: number;
 	currency_code: string;
 };
 
-type SummOrderItemDaily = {
+type SummOrderItemDaily_ = {
 	prod_code: string;
 	prod_name: string;
 	prod_variant_id?: string;
@@ -15,19 +15,19 @@ type SummOrderItemDaily = {
 	currency_code: string;
 };
 
-type SummDaily = {
+type SummDaily_ = {
 	biz_date: Date;
-	summ_order: SummOrderTxnDaily;
-	summ_order_item: SummOrderItemDaily;
+	summ_order: SummOrderTxnDaily_;
+	summ_order_item: SummOrderItemDaily_;
 };
 
-type SummCustomer = {
+type SummCustomer_ = {
 	customer_no: Date;
 	total_orders: number;
 	total_spent: number;
 };
 
 export type GetDashboardSummResp = {
-	daily_summaries: SummDaily[];
-	top_purchased_customers: SummCustomer[];
+	daily_summaries: SummDaily_[];
+	top_purchased_customers: SummCustomer_[];
 };

--- a/stores/SummOrder/SummOrder.ts
+++ b/stores/SummOrder/SummOrder.ts
@@ -1,9 +1,12 @@
+import type { SummDaily, SummCustomer } from '~/utils/types/summ-orders';
 import { failedNotification } from '../AppUi/AppUi';
 
 export const useSummOrderStore = defineStore('summOrderStore', {
 	state: () => ({
 		loading: false as boolean,
 		errors: [] as string[],
+		daily_summaries: [] as SummDaily[],
+		top_purchased_customers: [] as SummCustomer[],
 	}),
 	actions: {
 		async getDashboardSummary(start_date: string, end_date: string) {
@@ -11,14 +14,15 @@ export const useSummOrderStore = defineStore('summOrderStore', {
 			const { $api } = useNuxtApp();
 
 			try {
-				await $api.summOrder
-					.getDashboardOrderSummary({
-						start_date,
-						end_date,
-					})
-					.then((data) => {
-						console.log(data);
-					});
+				const data = await $api.summOrder.getDashboardOrderSummary({
+					start_date,
+					end_date,
+				});
+
+				this.daily_summaries = data.daily_summaries;
+				this.top_purchased_customers = data.top_purchased_customers;
+
+				console.log(data);
 			} catch (err: any) {
 				console.error(err);
 				failedNotification(err.message);

--- a/utils/types/summ-orders.ts
+++ b/utils/types/summ-orders.ts
@@ -1,0 +1,28 @@
+type SummOrderTxnDaily = {
+	biz_date: string;
+	total_orders: number;
+	total_qty: number;
+	currency_code: string;
+};
+
+type SummOrderItemDaily = {
+	prod_code: string;
+	prod_name: string;
+	prod_variant_id?: string;
+	prod_variant_name?: string;
+	total_qty: number;
+	total_net_amt: number;
+	currency_code: string;
+};
+
+export type SummDaily = {
+	biz_date: string;
+	summ_order: SummOrderTxnDaily;
+	summ_order_item: SummOrderItemDaily;
+};
+
+export type SummCustomer = {
+	customer_no: string;
+	total_orders: number;
+	total_spent: number;
+};


### PR DESCRIPTION
- Deleted the unused Orders.vue component from the Dashboard.
- Updated type definitions in dashboard-summ.ts to include new suffixes for clarity.
- Modified GeneralInfo.vue to handle potential null values for product type.
- Adjusted index.vue to replace DashboardChart components with DashboardChartOrders for improved dashboard representation.
- Enhanced SummOrder store to properly assign fetched summary data to state properties.