### PR TITLE
Feature: Add Order and Sales Summary Pages

### DIFF
--- a/pages/order-summary/order-customers.vue
+++ b/pages/order-summary/order-customers.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Order Customer Summary',
+		icon: ICONS.LIST,
+		to: '/summary/order-customers',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/order-summary/order-items.vue
+++ b/pages/order-summary/order-items.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Order Item Summary',
+		icon: ICONS.LIST,
+		to: '/summary/order-items',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/order-summary/orders.vue
+++ b/pages/order-summary/orders.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Order Summary',
+		icon: ICONS.LIST,
+		to: '/summary/orders',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/sales-summary/sales-customers.vue
+++ b/pages/sales-summary/sales-customers.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Sales Customer Summary',
+		icon: ICONS.LIST,
+		to: '/sales-summary/sales-customers',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/sales-summary/sales-items.vue
+++ b/pages/sales-summary/sales-items.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Sales Item Summary',
+		icon: ICONS.LIST,
+		to: '/sales-summary/sales-items',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/sales-summary/sales.vue
+++ b/pages/sales-summary/sales.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UBreadcrumb :links="links" />
+		<div class="base"></div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+const links = [
+	{
+		label: 'Sales Summary',
+		icon: ICONS.LIST,
+		to: '/sales-summary/sales',
+	},
+];
+</script>
+
+<style scoped lang="postcss"></style>

--- a/stores/AppUi/AppUi.ts
+++ b/stores/AppUi/AppUi.ts
@@ -10,6 +10,46 @@ const merchantNavigation = [
 		isCollapsed: false,
 	},
 	{
+		title: 'Summ Order',
+		icon: ICONS.ORDER_SUMMARY,
+		to: '/order-summary',
+		isCollapsed: false,
+		children: [
+			{
+				title: 'Orders',
+				to: '/order-summary/orders',
+			},
+			{
+				title: 'Items',
+				to: '/order-summary/order-items',
+			},
+			{
+				title: 'Customers',
+				to: '/order-summary/order-customers',
+			},
+		],
+	},
+	{
+		title: 'Summ Sales',
+		icon: ICONS.SALES_SUMMARY,
+		to: '/sales-summary',
+		isCollapsed: false,
+		children: [
+			{
+				title: 'Sales',
+				to: '/sales-summary/sales',
+			},
+			{
+				title: 'Items',
+				to: '/sales-summary/sales-items',
+			},
+			{
+				title: 'Customers',
+				to: '/sales-summary/sales-customers',
+			},
+		],
+	},
+	{
 		title: 'Booking / Orders',
 		icon: ICONS.ORDER,
 		to: '/orders',

--- a/utils/icons.ts
+++ b/utils/icons.ts
@@ -28,4 +28,6 @@ export const ICONS = {
 	ARROW_LEFT: 'i-material-symbols-arrow-back-rounded',
 	ARROW_RIGHT: 'i-material-symbols-arrow-forward-rounded',
 	MENU_OPEN_ROUNDED: 'i-material-symbols-arrow-forward-rounded',
+	ORDER_SUMMARY: 'i-material-symbols-bar-chart-4-bars-rounded',
+	SALES_SUMMARY: 'i-material-symbols-auto-graph-rounded',
 };


### PR DESCRIPTION
- Introduced new Vue components for Order and Sales summaries, including order-customers.vue, order-items.vue, orders.vue, sales-customers.vue, sales-items.vue, and sales.vue.
- Each component features a breadcrumb navigation and is structured to display relevant summary information.
- Updated AppUi store to include navigation links for the new summary pages.
- Added new icon constants for order and sales summaries in icons.ts.