### PR TITLE
Add tax rule selection to outlet creation and detail components

### DIFF
--- a/components/Form/OutletCreation.vue
+++ b/components/Form/OutletCreation.vue
@@ -15,6 +15,12 @@
 				v-model:latitude="new_outlet.latitude"
 				required-lat-lng
 			/>
+
+			<div class="mt-4">
+				<h6 class="text-secondary-700 text-sm font-bold">Tax Rule</h6>
+				<ZSelectMenuTaxRule v-model:tax-rule="new_outlet.tax_rule" @update:tax-rule="updateTaxRule" />
+			</div>
+
 			<!-- *********************** General Info *********************** -->
 			<div class="flex-center text-center mt-3">
 				<UButton size="md" color="green" variant="solid" type="submit" block :loading="adding">Create</UButton>
@@ -37,8 +43,12 @@ onMounted(() => {
 	outletStore.resetNewOutlet();
 });
 
+const updateTaxRule = (tax_rule: any) => {
+	new_outlet.value.tax_rule = tax_rule.code;
+};
+
 const onSubmit = async (event: FormSubmitEvent<Schema>) => {
-	const { code, description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude } = event.data;
+	const { code, description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude, tax_rule } = event.data;
 
 	new_outlet.value = {
 		code,
@@ -52,6 +62,7 @@ const onSubmit = async (event: FormSubmitEvent<Schema>) => {
 		postal_code,
 		longitude,
 		latitude,
+		tax_rule,
 	};
 
 	await outletStore.createOutlet();

--- a/components/Z/Modal/Outlet/Detail.vue
+++ b/components/Z/Modal/Outlet/Detail.vue
@@ -26,16 +26,8 @@
 				/>
 				<!-- *********************** General Info *********************** -->
 				<div class="mt-4">
-					<!-- <h6 class="text-secondary-700 text-sm font-bold">Values</h6>
-					<div v-if="state.option.values.length > 0">
-						<div v-for="(value, index) in state.option.values" :key="index" class="w-full flex-jbetween-icenter space-y-2">
-							<h5 class="text-neutral-300">#{{ value.id }}</h5>
-
-							<UFormGroup v-slot="{ error }" name="value" required>
-								<UInput v-model="state.option.values[index].value" :trailing-icon="error ? ICONS.ERROR_OUTLINE : undefined" placeholder="Value" />
-							</UFormGroup>
-						</div>
-					</div> -->
+					<h6 class="text-secondary-700 text-sm font-bold">Tax Rule</h6>
+					<ZSelectMenuTaxRule v-model:tax-rule="state.outlet.tax_rule" @update:tax-rule="updateTaxRule" />
 				</div>
 
 				<!-- *********************** General Info *********************** -->
@@ -84,16 +76,21 @@ const state = reactive({
 		postal_code: props.outlet.postal_code,
 		longitude: props.outlet.longitude,
 		latitude: props.outlet.latitude,
+		tax_rule: props.outlet.tax_rule,
 	},
 });
 
 const tagStore = useProductTagStore();
 const { updating } = storeToRefs(tagStore);
 
-const onSubmit = async (event: FormSubmitEvent<Schema>) => {
-	const { description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude } = event.data;
+const updateTaxRule = (tax_rule: any) => {
+	state.outlet.tax_rule = tax_rule.code;
+};
 
-	emit('update', { description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude });
+const onSubmit = async (event: FormSubmitEvent<Schema>) => {
+	const { description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude, tax_rule } = event.data;
+
+	emit('update', { description, address1, address2, address3, city, country_code, state, postal_code, longitude, latitude, tax_rule });
 };
 
 const onDelete = () => {

--- a/components/Z/SelectMenu/TaxRule.vue
+++ b/components/Z/SelectMenu/TaxRule.vue
@@ -1,0 +1,43 @@
+<template>
+	<UFormGroup name="tags" class="mt-2">
+		<USelectMenu v-model="tax_rule" v-model:query="query" :options="tax_rules_options" searchable size="md" option-attribute="code" by="code">
+			<template #label>
+				<span v-if="tax_rule" class="truncate">{{ tax_rule.code }}</span>
+				<span v-else class="text-gray-400">Select Tax Rule</span>
+			</template>
+		</USelectMenu>
+	</UFormGroup>
+</template>
+
+<script lang="ts" setup>
+import type { TaxRuleInput, TaxRule } from '~/utils/types/tax-rule';
+
+const query = ref('');
+const taxRuleStore = useTaxRuleStore();
+const { tax_rules: tax_rules_options } = storeToRefs(taxRuleStore);
+
+const props = defineProps<{ taxRule: TaxRule | TaxRuleInput | undefined }>();
+
+const emit = defineEmits(['update:taxRule']);
+
+onMounted(async () => {
+	if (tax_rules_options.value.length === 0) {
+		await taxRuleStore.getTaxRules();
+	}
+});
+
+const tax_rule = computed({
+	get() {
+		if (typeof props.taxRule === 'string') {
+			return tax_rules_options.value.find((tax_rule) => tax_rule.code === props.taxRule);
+		}
+
+		return props.taxRule ?? undefined;
+	},
+	set(value) {
+		emit('update:taxRule', value);
+	},
+});
+</script>
+
+<style scoped lang="postcss"></style>

--- a/pages/outlets/index.vue
+++ b/pages/outlets/index.vue
@@ -100,7 +100,6 @@ const selectOutlet = async (outlet: Outlet) => {
 	modal.open(ZModalOutletDetail, {
 		outlet: JSON.parse(JSON.stringify(outlet)),
 		onUpdate: async (_outlet: Outlet) => {
-			console.log(_outlet);
 			await outletStore.updateOutlet(outlet.code, _outlet);
 			modal.close();
 		},

--- a/pages/products/categories/index.vue
+++ b/pages/products/categories/index.vue
@@ -34,7 +34,7 @@
 							</template>
 
 							<template #total_items-data="{ row }">
-								<h5 class="text-neutral-500 text-center">{{ row.total_items }}</h5>
+								<h5 class="text-neutral-500 text-center">{{ row.total_products ?? 0 }}</h5>
 							</template>
 
 							<template #empty-state>

--- a/pages/products/tags/index.vue
+++ b/pages/products/tags/index.vue
@@ -26,7 +26,7 @@
 							</template>
 
 							<template #total_items-data="{ row }">
-								<h5 class="text-neutral-500 text-center">{{ row.total_items }}</h5>
+								<h5 class="text-neutral-500 text-center">{{ row.total_products ?? 0 }}</h5>
 							</template>
 
 							<template #empty-state>

--- a/repository/modules/outlets/models/request/update-outlet.req.ts
+++ b/repository/modules/outlets/models/request/update-outlet.req.ts
@@ -9,4 +9,5 @@ export type UpdateOutletReq = {
 	postal_code: string | undefined;
 	longitude: number | undefined;
 	latitude: number | undefined;
+	tax_rule: string | undefined;
 };

--- a/repository/modules/outlets/outlet.ts
+++ b/repository/modules/outlets/outlet.ts
@@ -26,33 +26,33 @@ class OutletModule extends HttpFactory {
 		});
 	}
 
-	async create(tag: CreateOutletReq): Promise<OutletResp> {
+	async create(outlet: CreateOutletReq): Promise<OutletResp> {
 		return await this.call<any>({
 			method: 'POST',
 			url: `${this.RESOURCE.Create()}`,
-			body: tag,
+			body: outlet,
 		});
 	}
 
-	async update(code: string, tag: UpdateOutletReq): Promise<OutletResp> {
+	async update(code: string, outlet: UpdateOutletReq): Promise<OutletResp> {
 		return await this.call<any>({
 			method: 'PATCH',
 			url: `${this.RESOURCE.Update(code)}`,
-			body: tag,
+			body: outlet,
 		});
 	}
 
-	async delete(tag: OutletReq): Promise<OutletResp> {
+	async delete(outlet: OutletReq): Promise<OutletResp> {
 		return await this.call<any>({
 			method: 'DELETE',
-			url: `${this.RESOURCE.Delete(tag.code)}`,
+			url: `${this.RESOURCE.Delete(outlet.code)}`,
 		});
 	}
 
-	async restore(tag: OutletReq): Promise<OutletResp> {
+	async restore(outlet: OutletReq): Promise<OutletResp> {
 		return await this.call<any>({
 			method: 'PATCH',
-			url: `${this.RESOURCE.Restore(tag.code)}`,
+			url: `${this.RESOURCE.Restore(outlet.code)}`,
 		});
 	}
 }

--- a/stores/Outlet/Outlet.ts
+++ b/stores/Outlet/Outlet.ts
@@ -15,6 +15,7 @@ const initialEmptyOutlet: OutletCreate = {
 	postal_code: undefined,
 	longitude: undefined,
 	latitude: undefined,
+	tax_rule: undefined,
 };
 
 export const useOutletStore = defineStore('outletStore', {
@@ -62,8 +63,11 @@ export const useOutletStore = defineStore('outletStore', {
 				const { data, '@odata.count': total } = await $api.outlet.getMany({
 					$top: this.page_size,
 					$count: true,
+					$expand: 'tax_rule',
 					$skip: (this.current_page - 1) * this.page_size,
 				});
+
+				console.log(data);
 
 				if (data) {
 					if (this.current_page > 1 && this.total_outlets > this.outlets.length) {
@@ -137,6 +141,7 @@ export const useOutletStore = defineStore('outletStore', {
 					postal_code: outlet.postal_code,
 					longitude: outlet.longitude || undefined,
 					latitude: outlet.latitude || undefined,
+					tax_rule: outlet.tax_rule as string | undefined,
 				});
 
 				if (data.outlet) {

--- a/stores/ProductCategory/ProductCategory.ts
+++ b/stores/ProductCategory/ProductCategory.ts
@@ -70,6 +70,7 @@ export const useProductCategoryStore = defineStore('productCategoryStore', {
 				const { data, '@odata.count': total } = await $api.category.getMany({
 					$top: this.page_size,
 					$count: true,
+					$expand: 'products',
 					$skip: (this.current_page - 1) * this.page_size,
 				});
 

--- a/stores/ProductTag/ProductTag.ts
+++ b/stores/ProductTag/ProductTag.ts
@@ -53,6 +53,8 @@ export const useProductTagStore = defineStore('productTagStore', {
 				const { data, '@odata.count': total } = await $api.tag.getMany({
 					$top: this.page_size,
 					$count: true,
+					$expand: 'products',
+					$orderby: 'value asc',
 					$skip: (this.current_page - 1) * this.page_size,
 				});
 

--- a/utils/schema/Outlet/Create/OutletValidation.ts
+++ b/utils/schema/Outlet/Create/OutletValidation.ts
@@ -12,4 +12,5 @@ export const CreateOutletValidation = z.object({
 	postal_code: z.string(),
 	longitude: z.number().optional(),
 	latitude: z.number().optional(),
+	tax_rule: z.string().optional(),
 });

--- a/utils/schema/Outlet/Update/OutletValidation.ts
+++ b/utils/schema/Outlet/Update/OutletValidation.ts
@@ -11,4 +11,5 @@ export const UpdateOutletValidation = z.object({
 	postal_code: z.string(),
 	longitude: z.number().optional().nullable(),
 	latitude: z.number().optional().nullable(),
+	tax_rule: z.string().optional().nullable(),
 });

--- a/utils/types/category.ts
+++ b/utils/types/category.ts
@@ -1,4 +1,5 @@
 import type { Image } from './image';
+import type { Product } from './product';
 
 export type CategoryInput = {
 	code: string;
@@ -18,4 +19,8 @@ export type Category = {
 	parent_category_code?: string | undefined;
 	parent_category?: Category | undefined;
 	category_children?: Category[] | undefined;
+
+	products?: Product[] | undefined;
+
+	total_products?: number;
 };

--- a/utils/types/form/outlet-creation.ts
+++ b/utils/types/form/outlet-creation.ts
@@ -1,3 +1,5 @@
+import type { TaxRuleInput } from '../tax-rule';
+
 export type OutletCreate = {
 	code: string | undefined;
 	description: string | undefined;
@@ -10,4 +12,5 @@ export type OutletCreate = {
 	postal_code: string | undefined;
 	longitude: number | undefined;
 	latitude: number | undefined;
+	tax_rule: TaxRuleInput | undefined;
 };

--- a/utils/types/outlet.ts
+++ b/utils/types/outlet.ts
@@ -1,3 +1,5 @@
+import type { TaxRuleInput } from './tax-rule';
+
 export type Outlet = {
 	code: string;
 	description: string;
@@ -10,5 +12,6 @@ export type Outlet = {
 	postal_code: string;
 	longitude?: number | undefined;
 	latitude?: number | undefined;
+	tax_rule?: string | TaxRuleInput | undefined;
 	metadata?: Record<string, unknown> | undefined;
 };

--- a/utils/types/tax-rule.ts
+++ b/utils/types/tax-rule.ts
@@ -1,5 +1,9 @@
 import type { TaxRuleDetail } from './tax-rule-detail';
 
+export type TaxRuleInput = {
+	code: string;
+};
+
 export type TaxRule = {
 	code: string;
 	description: string;


### PR DESCRIPTION
- Introduced a new ZSelectMenuTaxRule component for selecting tax rules in OutletCreation.vue and Detail.vue.
- Updated the outlet creation and update logic to include tax_rule in the data model.
- Enhanced validation schemas to accommodate tax_rule in outlet creation and update requests.
- Refactored outlet store to manage tax_rule state and API interactions effectively.